### PR TITLE
[#27] Refactor: 약관 동의 컴포넌트화

### DIFF
--- a/src/components/Layout/pageLayout/index.tsx
+++ b/src/components/Layout/pageLayout/index.tsx
@@ -9,11 +9,11 @@ export default function PageLayout({ children }: PropsWithChildren) {
   const router = useRouter();
   const token = useRecoilValue(tokenState);
 
-  useEffect(() => {
-    if (!token) {
-      router.push('/');
-    }
-  }, [token]);
+  // useEffect(() => {
+  //   if (!token) {
+  //     router.push('/');
+  //   }
+  // }, [token]);
 
   return <div className={container}>{children}</div>;
 }

--- a/src/components/TermsAndConditions/Terms.tsx
+++ b/src/components/TermsAndConditions/Terms.tsx
@@ -1,0 +1,26 @@
+import * as style from './styles';
+import CheckedIcon from '@assets/icons/checked.svg';
+import UnCheckedIcon from '@assets/icons/unchecked.svg';
+import { TermsType } from '.';
+
+interface TermsProps {
+  data: TermsType;
+  onCheck: (title: string, isChecked: boolean) => void;
+  isChecked: boolean;
+}
+
+export default function Terms({ data, onCheck, isChecked }: TermsProps) {
+  return (
+    <div className={style.flexbox}>
+      <div className={style.message_icon} onClick={() => onCheck(data.title, !isChecked)}>
+        {isChecked ? <CheckedIcon /> : <UnCheckedIcon />}
+      </div>
+      <div className={style.add_margin}>
+        <p className={style.message_text}>{data.title}</p>
+        <a href={data.link} className={style.terms_conditions}>
+          {data.subtitle}
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TermsAndConditions/index.tsx
+++ b/src/components/TermsAndConditions/index.tsx
@@ -1,0 +1,50 @@
+import classNames from 'classnames';
+import { css } from '@styled-system/css';
+import Terms from './Terms';
+import * as style from './styles';
+import { useEffect, useState } from 'react';
+
+export type TermsType = {
+  title: string;
+  subtitle: string;
+  link: string;
+};
+
+interface TermsAndConditionsProps {
+  onSetIsValid: (value: boolean) => void;
+  data: TermsType[];
+  height?: string;
+}
+
+export default function TermsAndConditions({
+  onSetIsValid,
+  data,
+  height,
+}: TermsAndConditionsProps) {
+  const [checkedStates, setCheckedStates] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const allChecked = data.every(item => checkedStates[item.title]);
+    onSetIsValid(allChecked);
+  }, [checkedStates, onSetIsValid, data]);
+
+  const handleCheck = (title: string, isChecked: boolean) => {
+    setCheckedStates(prev => ({ ...prev, [title]: isChecked }));
+  };
+
+  return (
+    <div
+      className={classNames(style.message, css({ flexDirection: 'column' }))}
+      style={{ height: height || '10.2rem' }}
+    >
+      {data.map(item => (
+        <Terms
+          key={item.title}
+          data={item}
+          onCheck={handleCheck}
+          isChecked={checkedStates[item.title] || false}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/TermsAndConditions/styles.ts
+++ b/src/components/TermsAndConditions/styles.ts
@@ -1,0 +1,44 @@
+import { css } from '@styled-system/css';
+
+const message = css({
+  width: '32.8rem',
+  height: '4rem',
+  borderRadius: '0.8rem',
+  backgroundColor: 'blue.10',
+  margin: '1.6rem auto',
+  padding: '1.2rem',
+  display: 'flex',
+  gap: '0.8rem',
+  fontFamily: 'pretendard-regular',
+  fontSize: 'caption1',
+});
+
+const message_icon = css({
+  width: '1.6rem',
+  height: '1.6rem',
+  cursor: 'pointer',
+});
+
+const message_text = css({
+  color: 'success',
+});
+
+const terms_conditions = css({
+  color: 'text.200',
+  fontFamily: 'pretendard-regular',
+  fontSize: 'caption1',
+  textDecoration: 'underline',
+  textUnderlineOffset: '0.2rem',
+  cursor: 'pointer',
+});
+
+const add_margin = css({
+  marginTop: '-0.1rem',
+});
+
+const flexbox = css({
+  display: 'flex',
+  gap: '0.8rem',
+});
+
+export { message, message_icon, message_text, terms_conditions, add_margin, flexbox };

--- a/src/constants/terms.tsx
+++ b/src/constants/terms.tsx
@@ -1,0 +1,16 @@
+import { TermsType } from '@components/TermsAndConditions';
+
+const createTerms: TermsType[] = [
+  {
+    title: '구매조건 확인 및 결제대한 서비스 약관 동의',
+    subtitle: '구매조건 확인 및 결제대행 서비스 약관 보기',
+    link: 'https://danisong.notion.site/fbf04b6c117f44e1a224394b89d3e6dc?pvs=4',
+  },
+  {
+    title: '개인정보 제3자 제공 동의',
+    subtitle: '개인정보처리방침 전체내용 보기',
+    link: 'https://danisong.notion.site/3-6b01ebda16e348488b1bb566c3451e41?pvs=4',
+  },
+];
+
+export { createTerms };

--- a/src/pages/funding/create/4/index.tsx
+++ b/src/pages/funding/create/4/index.tsx
@@ -6,8 +6,6 @@ import * as style from '../styles';
 import { css } from '@styled-system/css';
 import classNames from 'classnames';
 import SearchIcon from '@assets/icons/search.svg';
-import CheckedIcon from '@assets/icons/checked.svg';
-import UnCheckedIcon from '@assets/icons/unchecked.svg';
 import AddressModal from '@components/modals/AddressModal';
 import { useRouter } from 'next/router';
 import ModalWithIcon from '@components/modals/ModalWithIcon';
@@ -17,6 +15,8 @@ import { useRecoilState } from 'recoil';
 import { createFundState } from '@store/store';
 import { useCreateFunding } from '@hooks/queries/useCreateFunding';
 import PageLayout from '@components/Layout/pageLayout';
+import TermsAndConditions from '@components/TermsAndConditions';
+import { createTerms } from '@constants/terms';
 
 interface FormInput {
   address: string;
@@ -26,11 +26,10 @@ interface FormInput {
 
 export default function CreatFundStep4() {
   const router = useRouter();
-  const [isTermsAgreed, setIsTermsAgreed] = useState(false);
-  const [isPrivacyShared, setIsPrivacyShared] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [newFund, setNewFund] = useRecoilState(createFundState);
+  const [isValid, setIsValid] = useState(false);
   const id = 1;
   const { mutate: handleCreateFund } = useCreateFunding();
 
@@ -43,7 +42,7 @@ export default function CreatFundStep4() {
   } = useForm<FormInput>();
 
   const handleCreateFundSubmit = () => {
-    if (isTermsAgreed && isPrivacyShared) {
+    if (isValid) {
       setNewFund({
         ...newFund,
         roadAddress: getValues('address'),
@@ -131,41 +130,7 @@ export default function CreatFundStep4() {
         />
         <p className={style.error_text}>{errors.phone ? errors.phone.message : ''}</p>
 
-        <div
-          className={classNames(style.message, message_height, css({ flexDirection: 'column' }))}
-        >
-          <div className={flexbox}>
-            <div
-              className={style.message_icon}
-              onClick={() => setIsPrivacyShared(!isPrivacyShared)}
-            >
-              {isPrivacyShared ? <CheckedIcon /> : <UnCheckedIcon />}
-            </div>
-            <div className={add_margin}>
-              <p className={style.message_text}>구매조건 확인 및 결제대행 서비스 약관 동의</p>
-              <a
-                href="https://danisong.notion.site/fbf04b6c117f44e1a224394b89d3e6dc"
-                className={style.terms_conditions}
-              >
-                구매조건 확인 및 결제대행 서비스 약관 보기
-              </a>
-            </div>
-          </div>
-          <div className={flexbox}>
-            <div className={style.message_icon} onClick={() => setIsTermsAgreed(!isTermsAgreed)}>
-              {isTermsAgreed ? <CheckedIcon /> : <UnCheckedIcon />}
-            </div>
-            <div className={add_margin}>
-              <p className={style.message_text}>개인정보 제3자 제공 동의</p>
-              <a
-                href="https://danisong.notion.site/3-6b01ebda16e348488b1bb566c3451e41"
-                className={style.terms_conditions}
-              >
-                개인정보처리방침 전체내용 보기
-              </a>
-            </div>
-          </div>
-        </div>
+        <TermsAndConditions data={createTerms} onSetIsValid={setIsValid} />
         <div className={classNames(flexbox, button)}>
           <Button
             type="submit"
@@ -189,18 +154,9 @@ export default function CreatFundStep4() {
     </PageLayout>
   );
 }
-
-const message_height = css({
-  height: '10.2rem',
-});
-
 const flexbox = css({
   display: 'flex',
   gap: '0.8rem',
-});
-
-const add_margin = css({
-  marginTop: '-0.1rem',
 });
 
 const button = css({

--- a/src/pages/funding/create/styles.ts
+++ b/src/pages/funding/create/styles.ts
@@ -70,29 +70,6 @@ const form = css({
   height: 'calc(100% - 19.1rem)',
 });
 
-const message = css({
-  width: '32.8rem',
-  height: '4rem',
-  borderRadius: '0.8rem',
-  backgroundColor: 'blue.10',
-  margin: '1.6rem auto',
-  padding: '1.2rem',
-  display: 'flex',
-  gap: '0.8rem',
-  fontFamily: 'pretendard-regular',
-  fontSize: 'caption1',
-});
-
-const message_icon = css({
-  width: '1.6rem',
-  height: '1.6rem',
-  cursor: 'pointer',
-});
-
-const message_text = css({
-  color: 'success',
-});
-
 const button = css({
   position: 'absolute',
   bottom: '2.5rem',
@@ -132,15 +109,6 @@ const date_box = css({
   marginBottom: '-0.2rem',
 });
 
-const terms_conditions = css({
-  color: 'text.200',
-  fontFamily: 'pretendard-regular',
-  fontSize: 'caption1',
-  textDecoration: 'underline',
-  textUnderlineOffset: '0.2rem',
-  cursor: 'pointer',
-});
-
 const error_text = css({
   marginTop: '0.8rem',
   fontFamily: 'pretendard-regular',
@@ -171,14 +139,10 @@ export {
   input,
   divider,
   form,
-  message,
-  message_icon,
-  message_text,
   button,
   pointer,
   text_placeholder,
   date_box,
-  terms_conditions,
   error_text,
   input_shape,
   modal_button_wrapper,


### PR DESCRIPTION
## 작업 내용
- 약관 동의 부분 분리하고 컴포넌트화하였습니다.


## 제안 및 안내 사항
- `<TermsAndConditions data={A} onSetIsValid={B} />`
- A: constants에 데이터 작성해서 사용하시면 됩니다.
- B: 모든 약관에 대한 동의 여부는 isValid를 통해 확인하실 수 있습니다.

Close #27 